### PR TITLE
Added test for '_public/js/dotUseMe'

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -95,7 +95,7 @@ module.exports = class JadeAngularJsCompiler
 
   #TODO: сделать async
   prepareResult: (compiled) ->
-    pathes = (result.sourceFiles for result in compiled when result.path is '_public\\js\\dontUseMe')[0]
+    pathes = (result.sourceFiles for result in compiled when result.path is '_public\\js\\dontUseMe' or result.path is '_public\/js\/dontUseMe')[0]
 
     return [] if pathes is undefined
 


### PR DESCRIPTION
This makes jade-angular-brunch compatible with *nix systems .

I believe that '_public" could also be extracted, but I wasn't sure how to access that variable
